### PR TITLE
Travis CI build with javadoc and sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ jdk:
 #  - openjdk7
 #  - oraclejdk7
   - oraclejdk8
+
+build: mvn test -B generate-sources javadoc:javadoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ script:
     ## Example script entry from GeoServer:
     #- mvn -f src/pom.xml -B -U -T2 -fae -Prelease clean install && mvn -f src/community/pom.xml -B -U -T2 -fae -DskipTests -Prelease -PcommunityRelease clean install
     #
-    -mvn clean install -B -U -T2 -fae
+    - mvn clean install -B -U -T2 -fae

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,46 @@
-## Travis Continuous Integration (Travis CI) build script for the WWSK
-
+## WWSK Travis Continuous Integration (Travis CI) build script
 language: java
 
-jdk:
-#  - openjdk7
-#  - oraclejdk7
-  - oraclejdk8
+# Cache the local maven repository
+cache:
+  directories:
+    - "$HOME/.m2"
 
-build: mvn test -B generate-sources javadoc:javadoc
+# Remove the (cached) local user-specific maven settings
+before_install:
+  - rm ~/.m2/settings.xml
+  
+# Define the JDK(s) to build against
+jdk:
+  - oraclejdk8
+#  - oraclejdk7
+#  - openjdk7
+
+script:
+    ## Maven Phases
+    # validate: validate the project
+    # clean:    cleans up artifacts by prior builds
+    # compile:  compile the source
+    # test:     test the compiled code using unit testing framework
+    # package:  package compile code into dist. formats, (e.g., JAR files)
+    # integration_test: deploy package to where integration tests can be run
+    # verify:   run any checks to verify the package is valid
+    # install:  install the package into the local repository
+    # deploy:   copies the final package to the remote repository
+    # site:     generates the site documentation
+    # 
+    ## Maven Plugins
+    # generate-sources 
+    # javadoc:javadoc
+    #
+    ## Maven Commands
+    # -B (--batch-mode) Run in non-interactive model
+    # -U (--update-snapshots) Forces a check for missing releases and updated snapshots on remote repos
+    # -T2 (--threads <arg>) Thread count: 2
+    # -fae (--fail-at-end) Only fail the build afterwards; allow non-impacted builds to continue
+    # -P (--activate-profiles <arg>) Comma-delimited list of profiles to activate
+    #
+    ## Example script entry from GeoServer:
+    #- mvn -f src/pom.xml -B -U -T2 -fae -Prelease clean install && mvn -f src/community/pom.xml -B -U -T2 -fae -DskipTests -Prelease -PcommunityRelease clean install
+    #
+    -mvn clean install -B -U -T2 -fae

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 ## WWSK Travis Continuous Integration (Travis CI) build script
 language: java
 
+# Define the JDK(s) to build against
+jdk:
+  - oraclejdk8
+#  - oraclejdk7
+#  - openjdk7
+
 # Cache the local maven repository
 cache:
   directories:
@@ -10,12 +16,11 @@ cache:
 before_install:
   - rm ~/.m2/settings.xml
   
-# Define the JDK(s) to build against
-jdk:
-  - oraclejdk8
-#  - oraclejdk7
-#  - openjdk7
-
+# Before running the build, the default Travis CI behavior installs dependencies: 
+#   mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+# We skip the installation step as we perform the dependency management in the build step (script)
+install: true
+  
 script:
     ## Maven Phases
     # validate: validate the project

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 # We skip the installation step as we perform the dependency management in the build step (script)
 install: true
   
+# Build the WWSK using from the parent POM
 script:
     ## Maven Phases
     # validate: validate the project
@@ -48,4 +49,4 @@ script:
     ## Example script entry from GeoServer:
     #- mvn -f src/pom.xml -B -U -T2 -fae -Prelease clean install && mvn -f src/community/pom.xml -B -U -T2 -fae -DskipTests -Prelease -PcommunityRelease clean install
     #
-    - mvn clean install -B -U -T2 -fae
+    - mvn clean install -B -U -T2 -fae -Prelease

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+## Travis Continuous Integration (Travis CI) build script for the WWSK
+
+language: java
+
+jdk:
+#  - openjdk7
+#  - oraclejdk7
+  - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         </license>
     </licenses>
     
-        <properties>
+    <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--The GeoServer version used in this build; used for artifacts and assemblies-->
         <gs.version>2.10.0</gs.version>
@@ -1350,7 +1350,16 @@
                     <artifactId>maven-war-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
-            </plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.4</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+
+                </plugin>
+            </plugins>              
         </pluginManagement>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1335,18 +1335,22 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.8</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>2.10</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
@@ -1354,10 +1358,19 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.4</version>
-                <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                </configuration>
-
+                    <configuration>
+                        <!--Prevent the javadoc-plugin from generating errors that terminate a build-->
+                        <additionalparam>-Xdoclint:none</additionalparam>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <configuration>
+                        <!--Prevent the javadoc-plugin from generating errors that terminate a build-->
+                        <additionalparam>-Xdoclint:none</additionalparam>
+                    </configuration>
                 </plugin>
             </plugins>              
         </pluginManagement>

--- a/worldwind-gs-geopkg/pom.xml
+++ b/worldwind-gs-geopkg/pom.xml
@@ -169,6 +169,20 @@ application directory.
     
     
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>            
+            </plugin>
+        </plugins>
         <resources>
             <resource>
                 <directory>${basedir}/src/main/java</directory>

--- a/worldwind-gs-geopkg/pom.xml
+++ b/worldwind-gs-geopkg/pom.xml
@@ -182,6 +182,18 @@ application directory.
                     </execution>
                 </executions>            
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>            
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/worldwind-gs-geopkg/pom.xml
+++ b/worldwind-gs-geopkg/pom.xml
@@ -167,34 +167,50 @@ application directory.
         </dependency>
     </dependencies>
     
+    <profiles>
+        <!--Generate the javadocs and sources jar files when the "release" profile is activated-->
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
+            <dependencies/>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>            
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>            
+                    </plugin>               
+                </plugins>
+            </build>
+            <modules/>
+        </profile>
+    </profiles>
     
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>            
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>            
-            </plugin>
-        </plugins>
+        <plugins/>
         <resources>
             <resource>
                 <directory>${basedir}/src/main/java</directory>

--- a/worldwind-gs-wms/pom.xml
+++ b/worldwind-gs-wms/pom.xml
@@ -109,6 +109,20 @@
     </dependencies>
     
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>            
+            </plugin>
+        </plugins>
         <resources>
             <resource>
                 <directory>${basedir}/src/main/java</directory>

--- a/worldwind-gs-wms/pom.xml
+++ b/worldwind-gs-wms/pom.xml
@@ -122,6 +122,18 @@
                     </execution>
                 </executions>            
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>            
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/worldwind-gs-wms/pom.xml
+++ b/worldwind-gs-wms/pom.xml
@@ -108,33 +108,50 @@
         </dependency>
     </dependencies>
     
+    <profiles>
+        <!--Generate the javadocs and sources jar files when the "release" profile is activated-->
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
+            <dependencies/>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>            
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>            
+                    </plugin>               
+                </plugins>
+            </build>
+            <modules/>
+        </profile>
+    </profiles>
+    
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>            
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>            
-            </plugin>
-        </plugins>
+        <plugins/>
         <resources>
             <resource>
                 <directory>${basedir}/src/main/java</directory>

--- a/worldwind-gt-geopkg/pom.xml
+++ b/worldwind-gt-geopkg/pom.xml
@@ -152,6 +152,18 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>            
+            </plugin>
+            <plugin>
                 <groupId>org.geotools.maven</groupId>
                 <artifactId>xmlcodegen</artifactId>
                 <version>${gt.version}</version>

--- a/worldwind-gt-geopkg/pom.xml
+++ b/worldwind-gt-geopkg/pom.xml
@@ -164,6 +164,18 @@
                 </executions>            
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>            
+            </plugin>
+            <plugin>
                 <groupId>org.geotools.maven</groupId>
                 <artifactId>xmlcodegen</artifactId>
                 <version>${gt.version}</version>

--- a/worldwind-gt-geopkg/pom.xml
+++ b/worldwind-gt-geopkg/pom.xml
@@ -152,30 +152,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>            
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>            
-            </plugin>
-            <plugin>
                 <groupId>org.geotools.maven</groupId>
                 <artifactId>xmlcodegen</artifactId>
                 <version>${gt.version}</version>
@@ -203,5 +179,46 @@
             </plugin>
         </plugins>
     </build>
-
+    
+    <profiles>
+        <!--Generate the javadocs and sources jar files when the "release" profile is activated-->
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
+            <dependencies/>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>            
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>            
+                    </plugin>               
+                </plugins>
+            </build>
+            <modules/>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Added support for Travis Contiguous Integration (CI) with the addition of the _.travis.yml_ build script and modifications to the POM files to generate the _javadoc_ and _sources_ jar files.