### PR TITLE
JVM Memory Configuration

### DIFF
--- a/worldwind-geoserver-dist/src/main/resources/linux/env.sh
+++ b/worldwind-geoserver-dist/src/main/resources/linux/env.sh
@@ -11,8 +11,10 @@ export GEOSERVER_DATA_DIR=${GEOSERVER_HOME}/data_dir
 # -----------------------------------------------------------------------------
 # Set how much heap memory to allocate to GeoServer (min and max)
 # The max size of the "older generation" heap is controlled by the -Xms parameter.
+# Example for a 2GB allocation: 
+#   HEAP="-Xms2048m -Xmx2048m"
 # Leave blank to auto-select 25% of system memory
-HEAP="-Xms2048m -Xmx2048m"
+HEAP=
 
 # Set how much memory to set aside for new objects.
 # The "young generation" is further divided into an Eden, and Semi-spaces.

--- a/worldwind-geoserver-dist/src/main/resources/linux/setup-memory.sh
+++ b/worldwind-geoserver-dist/src/main/resources/linux/setup-memory.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# -----------------------------------------------------------------------------
+# Setup memory allocation for the World Wind Server Kit (WWSK) - Linux 
+# -----------------------------------------------------------------------------
+
+# Paths
+PWD=$(pwd)
+# Display a simple menu to configure the JVM heap memory allocation for Jetty/GeoServer
+echo
+echo "Memory allocation options:"
+PS3="Select a memory allocation option: "
+select MEM_CHOICE in Auto 512MB 1GB 2GB 4GB 8GB Skip Help
+do 
+    case "$MEM_CHOICE" in
+    (Auto) 
+        echo "Configuring the JVM to use 25% of the system memory for the heap allocation"
+        break 
+        ;;
+    (512MB) 
+        MEM_ALLOC=512m
+        break 
+        ;;
+    (1GB) 
+        MEM_ALLOC=1024m
+        break 
+        ;;
+    (2GB) 
+        MEM_ALLOC=2048m
+        break 
+        ;;
+    (4GB) 
+        MEM_ALLOC=4096m
+        break 
+        ;;
+    (8GB) 
+        MEM_ALLOC=8192m
+        break 
+        ;;
+    (Skip) 
+        echo "Skipping memory allocation setup"
+        break 
+        ;;
+    (Help) 
+        echo 
+        echo "Memory Allocation Help"
+        echo "======================"
+        echo "Auto:       Configures the Java Virtual Machine (JVM) to use "
+        echo "            25% of the system memory."
+        echo "512MB..8GB: Configures the JVM to use the selected allocation."
+        echo "Skip:       Skips the allocation. Makes no changes."
+        echo
+        ;;
+    (*) 
+        echo "Invalid selection. Try again (1..8)!" 
+        ;;
+    esac
+done  
+
+if [ ! -z "${MEM_ALLOC}" ]; then
+    ## Update the HEAP environment variable in the env.sh script.
+    ## Example:
+    ## HEAP="-Xms2048m -Xmx2048m"
+    ## We're using the s/PATTERN/REPLACEMENT/ regexp syntax with sed to update the script.
+    ## The ^ and $ are beginning/end-of-line markers; .* matches anything.
+    ## We're using the s;;; pattern instead of s/// to avoid conflicts with file paths.
+    echo "Configuring the JVM to use $MEM_CHOICE (${MEM_ALLOC}) for the heap allocation"
+    sed -i 's;^HEAP=.*$;HEAP="-xms'${MEM_ALLOC}' -xmx'${MEM_ALLOC}'";' env.sh
+elif [ "${MEM_CHOICE}" = "Auto" ]; then
+    sed -i 's;^HEAP=.*$;HEAP=;' env.sh
+fi
+
+
+echo  "Memory allocation setup complete"

--- a/worldwind-geoserver-dist/src/main/resources/linux/setup-memory.sh
+++ b/worldwind-geoserver-dist/src/main/resources/linux/setup-memory.sh
@@ -65,7 +65,7 @@ if [ ! -z "${MEM_ALLOC}" ]; then
     ## The ^ and $ are beginning/end-of-line markers; .* matches anything.
     ## We're using the s;;; pattern instead of s/// to avoid conflicts with file paths.
     echo "Configuring the JVM to use $MEM_CHOICE (${MEM_ALLOC}) for the heap allocation"
-    sed -i 's;^HEAP=.*$;HEAP="-xms'${MEM_ALLOC}' -xmx'${MEM_ALLOC}'";' env.sh
+    sed -i 's;^HEAP=.*$;HEAP="-Xms'${MEM_ALLOC}' -Xmx'${MEM_ALLOC}'";' env.sh
 elif [ "${MEM_CHOICE}" = "Auto" ]; then
     sed -i 's;^HEAP=.*$;HEAP=;' env.sh
 fi

--- a/worldwind-geoserver-dist/src/main/resources/linux/setup-memory.sh
+++ b/worldwind-geoserver-dist/src/main/resources/linux/setup-memory.sh
@@ -4,25 +4,26 @@
 # Setup memory allocation for the World Wind Server Kit (WWSK) - Linux 
 # -----------------------------------------------------------------------------
 
-# Paths
-PWD=$(pwd)
 # Display a simple menu to configure the JVM heap memory allocation for Jetty/GeoServer
+echo
+echo "Configuring the JVM heap memory allocation for Jetty/GeoServer."
+echo "The current allocation is: " `grep ^HEAP env.sh` " (Xms=min, Xmx=max, Blank=auto)"
 echo
 echo "Memory allocation options:"
 PS3="Select a memory allocation option: "
-select MEM_CHOICE in Auto 512MB 1GB 2GB 4GB 8GB Skip Help
+select MEM_CHOICE in Auto 1GB 1.5GB 2GB 4GB 8GB Other Skip Help
 do 
     case "$MEM_CHOICE" in
     (Auto) 
         echo "Configuring the JVM to use 25% of the system memory for the heap allocation"
         break 
         ;;
-    (512MB) 
-        MEM_ALLOC=512m
-        break 
-        ;;
     (1GB) 
         MEM_ALLOC=1024m
+        break 
+        ;;
+    (1.5GB) 
+        MEM_ALLOC=1536m
         break 
         ;;
     (2GB) 
@@ -37,6 +38,39 @@ do
         MEM_ALLOC=8192m
         break 
         ;;
+    (Other) 
+        echo 
+        echo "Enter the amount of memory to allocate to GeoServer."
+        echo "Enter an integer followed 'm' for megabytes or 'g' for gigabytes, e.g., for 1GB enter 1024m or 1g:"
+        read AMOUNT
+        # Assert something was entered
+        if ! [ -z $AMOUNT ]; then
+            # Assert megabytes/gigabytes is specified
+            if ! [[ $AMOUNT == *[g,m,G,M] ]]; then
+                echo "Memory unit-of-measure must be specified. Use 'm' for megabytes or 'g' for gigabytes."
+                echo
+                continue
+            else
+                # Assert the value in front of the UOM is an integer and it is > 0 
+                VALUE=${AMOUNT%[g,m,G,M]}
+                if ! [ $VALUE -eq $VALUE ] 2> /dev/null; then  # -eq generates an error if not an integer
+                    echo "Value must be an integer followed by 'm' or 'g'."
+                    echo
+                    continue
+                elif ! [ $VALUE -gt 0 ]; then
+                    echo "Value must be greater than zero."
+                    echo
+                    continue
+                fi
+            fi
+        else 
+            echo "No value entered."
+            echo
+            continue
+        fi
+        MEM_ALLOC=$AMOUNT     
+        break 
+        ;;
     (Skip) 
         echo "Skipping memory allocation setup"
         break 
@@ -47,12 +81,14 @@ do
         echo "======================"
         echo "Auto:       Configures the Java Virtual Machine (JVM) to use "
         echo "            25% of the system memory."
-        echo "512MB..8GB: Configures the JVM to use the selected allocation."
+        echo "1GB..8GB:   Configures the JVM to use the selected allocation."
+        echo "Other:      Enter a specific value in megabytes or gigabytes."
         echo "Skip:       Skips the allocation. Makes no changes."
         echo
         ;;
     (*) 
-        echo "Invalid selection. Try again (1..8)!" 
+        echo "Invalid selection. Try again (1..9)!" 
+        echo
         ;;
     esac
 done  
@@ -63,12 +99,11 @@ if [ ! -z "${MEM_ALLOC}" ]; then
     ## HEAP="-Xms2048m -Xmx2048m"
     ## We're using the s/PATTERN/REPLACEMENT/ regexp syntax with sed to update the script.
     ## The ^ and $ are beginning/end-of-line markers; .* matches anything.
-    ## We're using the s;;; pattern instead of s/// to avoid conflicts with file paths.
-    echo "Configuring the JVM to use $MEM_CHOICE (${MEM_ALLOC}) for the heap allocation"
-    sed -i 's;^HEAP=.*$;HEAP="-Xms'${MEM_ALLOC}' -Xmx'${MEM_ALLOC}'";' env.sh
+    echo "Configuring the JVM to use $MEM_CHOICE (${MEM_ALLOC}) for the HEAP allocation"
+    sed -i 's/^HEAP=.*$/HEAP="-Xms'${MEM_ALLOC}' -Xmx'${MEM_ALLOC}'"/' env.sh
 elif [ "${MEM_CHOICE}" = "Auto" ]; then
-    sed -i 's;^HEAP=.*$;HEAP=;' env.sh
+    sed -i 's/^HEAP=.*$/HEAP=/' env.sh
 fi
 
 
-echo  "Memory allocation setup complete"
+echo  "Memory allocation setup complete. You can reconfigure the memory by running ./setup-memory.sh"

--- a/worldwind-geoserver-dist/src/main/resources/linux/setup.sh
+++ b/worldwind-geoserver-dist/src/main/resources/linux/setup.sh
@@ -12,6 +12,9 @@ else
     # Setup Java
     source ./setup-java.sh $1
 
+    # Setup JVM memory allocation
+    source ./setup-memory.sh
+
     # Setup GDAL 
     source ./setup-gdal.sh $1
     

--- a/worldwind-geoserver-dist/src/main/resources/windows/run.bat
+++ b/worldwind-geoserver-dist/src/main/resources/windows/run.bat
@@ -11,7 +11,11 @@ rem See http://www.oracle.com/technetwork/systems/index-156457.html
 rem -----------------------------------------------------------------------------
 rem Set how much heap memory to allocate to GeoServer (min and max)
 rem The max size of the "older generation" heap is controlled by the -Xms parameter.
-set HEAP=-Xms2048m -Xmx2048m
+rem Example for 2GB memory allocation:
+rem     set HEAP=-Xms2048m -Xmx2048m
+rem Leave the HEAP blank to allocate 25% of the system memory to the JVM.
+set HEAP=
+
 
 rem Set how much memory to set aside for new objects.
 rem The "young generation" is further divided into an Eden, and Semi-spaces.


### PR DESCRIPTION
### Configurable Linux Memory Allocation
This pull request provides a setup-memory script that configures the JVM with a user selectable or a user editable memory allocation. The default value is 25% of the system memory.

Closes #57 

### Windows Memory Allocation
The Windows JVM allocation was changed from a fixed 2GB to 25% of the system memory.

Closes #99 