### PR TITLE
Fix NASA logo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://worldwind.arc.nasa.gov/css/images/nasa-logo.svg" height="100"/> 
+<img src="https://worldwind.arc.nasa.gov/img/nasa-logo.svg" height="100"/> 
 
 # WorldWindServerKit 
 


### PR DESCRIPTION
Closes [101](https://github.com/NASAWorldWind/NASAWorldWind.github.io/issues/101) 

Final fix for logo reference. Path to image has changed since we have migrated to hugo. This has been fixed.