### PR TITLE
Feature/#102 Control Flow

### DIFF
--- a/jmeter/wms_test/GeoServer Stress Test.jmx
+++ b/jmeter/wms_test/GeoServer Stress Test.jmx
@@ -2,14 +2,44 @@
 <jmeterTestPlan version="1.2" properties="3.1" jmeter="3.1 r1770033">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="GeoServer Stress Test" enabled="true">
-      <stringProp name="TestPlan.comments">Tutorial</stringProp>
+      <stringProp name="TestPlan.comments">Common variables used elsewhere are defined here.  See the GetMap [HTTP Request] for usage.</stringProp>
       <boolProp name="TestPlan.functional_mode">false</boolProp>
       <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
         <collectionProp name="Arguments.arguments">
-          <elementProp name="SERVER_ADDRESS" elementType="Argument">
-            <stringProp name="Argument.name">SERVER_ADDRESS</stringProp>
-            <stringProp name="Argument.value">192.168.1.222</stringProp>
+          <elementProp name="COBRA" elementType="Argument">
+            <stringProp name="Argument.name">COBRA</stringProp>
+            <stringProp name="Argument.value">192.168.2.2</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="APACHE" elementType="Argument">
+            <stringProp name="Argument.name">APACHE</stringProp>
+            <stringProp name="Argument.value">192.168.2.3</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="DEVICE" elementType="Argument">
+            <stringProp name="Argument.name">DEVICE</stringProp>
+            <stringProp name="Argument.value">localhost</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="JETTY" elementType="Argument">
+            <stringProp name="Argument.name">JETTY</stringProp>
+            <stringProp name="Argument.value">8080</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="TOMCAT" elementType="Argument">
+            <stringProp name="Argument.name">TOMCAT</stringProp>
+            <stringProp name="Argument.value">8084</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="WMS_ENDPOINT" elementType="Argument">
+            <stringProp name="Argument.name">WMS_ENDPOINT</stringProp>
+            <stringProp name="Argument.value">geoserver/wms</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="GWC_ENDPOINT" elementType="Argument">
+            <stringProp name="Argument.name">GWC_ENDPOINT</stringProp>
+            <stringProp name="Argument.value">geoserver/gwc/service/wms</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -23,13 +53,14 @@
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <intProp name="LoopController.loops">-1</intProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">30</stringProp>
-        <stringProp name="ThreadGroup.ramp_time">5</stringProp>
-        <longProp name="ThreadGroup.start_time">1490826449000</longProp>
-        <longProp name="ThreadGroup.end_time">1490826449000</longProp>
-        <boolProp name="ThreadGroup.scheduler">true</boolProp>
-        <stringProp name="ThreadGroup.duration">180</stringProp>
+        <stringProp name="ThreadGroup.num_threads">8</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <longProp name="ThreadGroup.start_time">1503787984000</longProp>
+        <longProp name="ThreadGroup.end_time">1503787984000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <stringProp name="TestPlan.comments">Each thread reads the &quot;next&quot; row from the CSV file</stringProp>
       </ThreadGroup>
       <hashTree>
         <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="WMS Request Defaults" enabled="true">
@@ -48,7 +79,7 @@
             </elementProp>
             <elementProp name="version" elementType="Argument">
               <stringProp name="Argument.name">version</stringProp>
-              <stringProp name="Argument.value">1.1.1</stringProp>
+              <stringProp name="Argument.value">1.3.0</stringProp>
               <stringProp name="Argument.desc">WMS version to use</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
@@ -60,7 +91,7 @@
             </elementProp>
             <elementProp name="layers" elementType="Argument">
               <stringProp name="Argument.name">layers</stringProp>
-              <stringProp name="Argument.value">nasa:world_topo_bathy</stringProp>
+              <stringProp name="Argument.value">proxy-auto-sensor</stringProp>
               <stringProp name="Argument.desc">Layer(s) to request</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
@@ -70,8 +101,8 @@
               <stringProp name="Argument.desc">Styles to apply</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
-            <elementProp name="srs" elementType="Argument">
-              <stringProp name="Argument.name">srs</stringProp>
+            <elementProp name="crs" elementType="Argument">
+              <stringProp name="Argument.name">crs</stringProp>
               <stringProp name="Argument.value">EPSG:4326</stringProp>
               <stringProp name="Argument.desc">CRS for bounding box</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
@@ -90,19 +121,15 @@
           <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config" enabled="true">
             <stringProp name="delimiter">,</stringProp>
             <stringProp name="fileEncoding"></stringProp>
-            <stringProp name="filename">global_0-4.csv</stringProp>
+            <stringProp name="filename">ft_biggs_10-19_4326_zoom.csv</stringProp>
             <boolProp name="quotedData">false</boolProp>
-            <boolProp name="recycle">true</boolProp>
+            <boolProp name="recycle">false</boolProp>
             <stringProp name="shareMode">shareMode.all</stringProp>
-            <boolProp name="stopThread">false</boolProp>
-            <stringProp name="variableNames">width,height,left,bottom,right,top</stringProp>
+            <boolProp name="stopThread">true</boolProp>
+            <stringProp name="variableNames">width,height,left,bottom,right,top,level</stringProp>
           </CSVDataSet>
           <hashTree/>
-          <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Constant Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">250</stringProp>
-          </ConstantTimer>
-          <hashTree/>
-          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GetMap HTTP Request" enabled="true">
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GetMap ${level}" enabled="true">
             <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
               <collectionProp name="Arguments.arguments">
                 <elementProp name="service" elementType="HTTPArgument">
@@ -128,7 +155,7 @@
                 </elementProp>
                 <elementProp name="bbox" elementType="HTTPArgument">
                   <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">${left},${bottom},${right},${top}</stringProp>
+                  <stringProp name="Argument.value">${bottom},${left},${top},${right}</stringProp>
                   <stringProp name="Argument.metadata">=</stringProp>
                   <boolProp name="HTTPArgument.use_equals">true</boolProp>
                   <stringProp name="Argument.name">bbox</stringProp>
@@ -168,12 +195,12 @@
                   <boolProp name="HTTPArgument.use_equals">true</boolProp>
                   <stringProp name="Argument.name">styles</stringProp>
                 </elementProp>
-                <elementProp name="srs" elementType="HTTPArgument">
+                <elementProp name="crs" elementType="HTTPArgument">
                   <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">${srs}</stringProp>
+                  <stringProp name="Argument.value">${crs}</stringProp>
                   <stringProp name="Argument.metadata">=</stringProp>
                   <boolProp name="HTTPArgument.use_equals">true</boolProp>
-                  <stringProp name="Argument.name">srs</stringProp>
+                  <stringProp name="Argument.name">crs</stringProp>
                 </elementProp>
                 <elementProp name="tiled" elementType="HTTPArgument">
                   <boolProp name="HTTPArgument.always_encode">false</boolProp>
@@ -190,13 +217,13 @@
                 </elementProp>
               </collectionProp>
             </elementProp>
-            <stringProp name="HTTPSampler.domain">${SERVER_ADDRESS}</stringProp>
-            <stringProp name="HTTPSampler.port">8080</stringProp>
+            <stringProp name="HTTPSampler.domain">${COBRA}</stringProp>
+            <stringProp name="HTTPSampler.port">${JETTY}</stringProp>
             <stringProp name="HTTPSampler.connect_timeout"></stringProp>
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
             <stringProp name="HTTPSampler.protocol"></stringProp>
             <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-            <stringProp name="HTTPSampler.path">geoserver/wms</stringProp>
+            <stringProp name="HTTPSampler.path">${WMS_ENDPOINT}</stringProp>
             <stringProp name="HTTPSampler.method">GET</stringProp>
             <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
             <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -204,9 +231,73 @@
             <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
             <boolProp name="HTTPSampler.monitor">false</boolProp>
             <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+            <stringProp name="TestPlan.comments">Path: use ${WMS_ENDPOINT} [geoserver/wms]   or    ${GWC_ENDPOINT} [geoserver/gwc/service/wms]</stringProp>
           </HTTPSamplerProxy>
-          <hashTree/>
+          <hashTree>
+            <SizeAssertion guiclass="SizeAssertionGui" testclass="SizeAssertion" testname="Size Assertion" enabled="false">
+              <stringProp name="Assertion.test_field">SizeAssertion.response_data</stringProp>
+              <stringProp name="SizeAssertion.size">1325</stringProp>
+              <intProp name="SizeAssertion.operator">3</intProp>
+              <stringProp name="TestPlan.comments">PNG size assersion</stringProp>
+            </SizeAssertion>
+            <hashTree/>
+            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assert Response Code 200" enabled="true">
+              <collectionProp name="Asserion.test_strings">
+                <stringProp name="49586">200</stringProp>
+              </collectionProp>
+              <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+              <boolProp name="Assertion.assume_success">false</boolProp>
+              <intProp name="Assertion.test_type">2</intProp>
+            </ResponseAssertion>
+            <hashTree/>
+            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assert Content-Type: ${format}" enabled="true">
+              <collectionProp name="Asserion.test_strings">
+                <stringProp name="1815351611">Content-Type: ${format}</stringProp>
+              </collectionProp>
+              <stringProp name="TestPlan.comments">Ensure an image was returned and not an XML error response.</stringProp>
+              <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+              <boolProp name="Assertion.assume_success">false</boolProp>
+              <intProp name="Assertion.test_type">16</intProp>
+            </ResponseAssertion>
+            <hashTree/>
+          </hashTree>
         </hashTree>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="Request and Response data" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
         <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
@@ -242,6 +333,7 @@
           </objProp>
           <stringProp name="filename"></stringProp>
           <boolProp name="useGroupName">true</boolProp>
+          <stringProp name="TestPlan.comments">Ignore the Throughput column in indivdual rows. Read the JMeter help for the Summary Report to understand how the &quot;Throughput&quot; column as it relates to the &quot;Label&quot; rows and threads.</stringProp>
         </ResultCollector>
         <hashTree/>
         <ResultCollector guiclass="GraphVisualizer" testclass="ResultCollector" testname="Graph Results" enabled="true">
@@ -280,8 +372,6 @@
           <stringProp name="filename"></stringProp>
         </ResultCollector>
         <hashTree/>
-        <Summariser guiclass="SummariserGui" testclass="Summariser" testname="Generate Summary Results" enabled="true"/>
-        <hashTree/>
         <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="true">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
@@ -318,17 +408,19 @@
           <stringProp name="filename"></stringProp>
         </ResultCollector>
         <hashTree/>
-        <ResultSaver guiclass="ResultSaverGui" testclass="ResultSaver" testname="Save Responses to a file" enabled="true">
+        <Summariser guiclass="SummariserGui" testclass="Summariser" testname="Generate Summary Results" enabled="true"/>
+        <hashTree/>
+        <ResultSaver guiclass="ResultSaverGui" testclass="ResultSaver" testname="Save Error Responses to a file" enabled="true">
           <stringProp name="FileSaver.filename">D:/temp/test</stringProp>
-          <boolProp name="FileSaver.errorsonly">false</boolProp>
+          <boolProp name="FileSaver.errorsonly">true</boolProp>
           <boolProp name="FileSaver.skipautonumber">false</boolProp>
           <boolProp name="FileSaver.skipsuffix">false</boolProp>
-          <boolProp name="FileSaver.successonly">true</boolProp>
+          <boolProp name="FileSaver.successonly">false</boolProp>
           <boolProp name="FileSaver.addTimstamp">true</boolProp>
         </ResultSaver>
         <hashTree/>
       </hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Web Feature Info Elevation Requests" enabled="true">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Web Feature Info Elevation Requests" enabled="false">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
@@ -548,7 +640,7 @@
         </ResultSaver>
         <hashTree/>
       </hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Web Coverage Requests" enabled="true">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Web Coverage Requests" enabled="false">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,11 @@
                 <version>${gs.version}</version>
                 <classifier>tests</classifier>
             </dependency>
+            <dependency>
+                <groupId>org.geoserver.extension</groupId>
+                <artifactId>gs-control-flow</artifactId>
+                <version>${gs.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.geoserver.security</groupId>

--- a/resources/data/base/controlflow.properties
+++ b/resources/data/base/controlflow.properties
@@ -3,7 +3,7 @@
 ## Every request in excess will be queued and executed when other requests complete 
 ## leaving some free execution slot.
 #ows.global=<count>
-
+##
 ### Per request control
 ## A per request type control can be demanded using the following syntax:
 #ows.<service>[.<request>[.<outputFormat>]]=<count>
@@ -11,7 +11,7 @@
 ##  <service> is the OWS service in question (at the time of writing can be wms, wfs, wcs)
 ##  <request>, optional, is the request type. For example, for the wms service it can be GetMap, GetFeatureInfo, DescribeLayer, GetLegendGraphics, GetCapabilities
 ##  <outputFormat>, optional, is the output format of the request. For example, for the wms GetMap request it could be image/png, image/gif and so on
-
+##
 ### Per user concurrency control
 ## There are two mechanisms to identify user requests. The first one is cookie based, 
 ## so it will work fine for browsers but not as much for other kinds of clients. The 
@@ -32,19 +32,26 @@
 ## To reject requests from a list of ip addresses:
 # ip.blacklist=<ip_addr1>,<ip_addr2>,...
 
-# if a request waits in queue for more than 60 seconds it's not worth executing,
+
+## Example
+# If a request waits in queue for more than 60 seconds it's not worth executing,
 # the client will  likely have given up by then
-timeout=60
-# don't allow the execution of more than 100 requests total in parallel
-ows.global=100
-# don't allow more than 10 GetMap in parallel
-ows.wms.getmap=10
-# don't allow more than 4 outputs with Excel output as it's memory bound
-ows.wfs.getfeature.application/msexcel=4
-# don't allow a single user to perform more than 6 requests in parallel
+#timeout=60
+
+# Don't allow the execution of more than 100 requests total in parallel
+#ows.global=100
+
+# Don't allow more than 10 GetMap in parallel
+#ows.wms.getmap=10
+
+# Don't allow more than 4 outputs with Excel output as it's memory bound
+#ows.wfs.getfeature.application/msexcel=4
+
+# Don't allow a single user to perform more than 6 requests in parallel
 # (6 being the Firefox default concurrency level at the time of writing)
-user=6
-# don't allow the execution of more than 16 tile requests in parallel
+#user=6
+
+# Don't allow the execution of more than 16 tile requests in parallel
 # (assuming a server with 4 cores, GWC empirical tests show that throughput
 # peaks up at 4 x number of cores. Adjust as appropriate to your system)
-ows.gwc=16
+#ows.gwc=16

--- a/resources/data/base/controlflow.properties
+++ b/resources/data/base/controlflow.properties
@@ -1,0 +1,50 @@
+### Total OWS request count
+## The global number of OWS requests executing in parallel can be specified with:
+## Every request in excess will be queued and executed when other requests complete 
+## leaving some free execution slot.
+#ows.global=<count>
+
+### Per request control
+## A per request type control can be demanded using the following syntax:
+#ows.<service>[.<request>[.<outputFormat>]]=<count>
+## Where:
+##  <service> is the OWS service in question (at the time of writing can be wms, wfs, wcs)
+##  <request>, optional, is the request type. For example, for the wms service it can be GetMap, GetFeatureInfo, DescribeLayer, GetLegendGraphics, GetCapabilities
+##  <outputFormat>, optional, is the output format of the request. For example, for the wms GetMap request it could be image/png, image/gif and so on
+
+### Per user concurrency control
+## There are two mechanisms to identify user requests. The first one is cookie based, 
+## so it will work fine for browsers but not as much for other kinds of clients. The 
+## second one is ip based, which works for any type of client but that can limit all 
+## the users sitting behind the same router. This avoids a single user (as identified 
+## by a cookie) to make too many requests in parallel:
+#user=<count>
+## Where <count> is the maximum number of requests a single user can execute in parallel.
+##
+## The following avoids a single ip address from making too many requests in parallel:
+# ip=<count>
+## Where <count> is the maximum number of requests a single ip address can execute in parallel.
+##
+## It is also possible to make this a bit more specific and throttle a single ip address instead by using the following:
+# ip.<ip_addr>=<count>
+## Where <count> is the maximum number of requests the ip speficied in <ip_addr> will execute in parallel.
+##
+## To reject requests from a list of ip addresses:
+# ip.blacklist=<ip_addr1>,<ip_addr2>,...
+
+# if a request waits in queue for more than 60 seconds it's not worth executing,
+# the client will  likely have given up by then
+timeout=60
+# don't allow the execution of more than 100 requests total in parallel
+ows.global=100
+# don't allow more than 10 GetMap in parallel
+ows.wms.getmap=10
+# don't allow more than 4 outputs with Excel output as it's memory bound
+ows.wfs.getfeature.application/msexcel=4
+# don't allow a single user to perform more than 6 requests in parallel
+# (6 being the Firefox default concurrency level at the time of writing)
+user=6
+# don't allow the execution of more than 16 tile requests in parallel
+# (assuming a server with 4 cores, GWC empirical tests show that throughput
+# peaks up at 4 x number of cores. Adjust as appropriate to your system)
+ows.gwc=16

--- a/resources/jai/setup-jai.sh
+++ b/resources/jai/setup-jai.sh
@@ -57,6 +57,7 @@ while getopts :jrhf: opt; do
     esac
 done
 
+# Define the path where the pure-java JAI files will be backed up
 GEOSERVER_SAVE_PATH=${GEOSERVER_LIB_PATH}/../save
 
 # Place in interactive mode if no command line arguments
@@ -156,7 +157,7 @@ if [[ $INSTALL_JAI ]]; then
         rm -r jai_imageio-1_1
 
         # Save original pure-java JAI jars
-        mkdir -p ${GEOSERVER_LIB_PATH}/../save
+        mkdir -p ${GEOSERVER_SAVE_PATH}
         mv ${GEOSERVER_LIB_PATH}/jai_core-1.1.3.jar ${GEOSERVER_SAVE_PATH}
         mv ${GEOSERVER_LIB_PATH}/jai_codec-1.1.3.jar ${GEOSERVER_SAVE_PATH}
         mv ${GEOSERVER_LIB_PATH}/jai_imageio-1.1.jar ${GEOSERVER_SAVE_PATH}

--- a/resources/jai/setup-jai.sh
+++ b/resources/jai/setup-jai.sh
@@ -4,12 +4,12 @@ set +x
 # -----------------------------------------------------------------------------
 # Setup JAI for the World Wind Server Kit (WWSK) - Linux
 # -----------------------------------------------------------------------------
+# This script assumes the JAI resources are alongside this script in root of the WWSK distribution
 
 # File and paths
 PWD=$(pwd)
-JAVA_HOME=${PWD}"/java"
-GEOSERVER_LIB_PATH=${PWD}"/webapps/geoserver/WEB-INF/lib"
-GEOSERVER_SAVE_PATH=${PWD}"/webapps/geoserver/WEB-INF/save"
+JAVA_HOME=${PWD}/java
+GEOSERVER_LIB_PATH=${PWD}/webapps/geoserver/WEB-INF/lib
 JAI_ZIP="jai-1_1_3-lib-linux-amd64.tar.gz"
 JAI_IMAGEIO_ZIP="jai_imageio-1_1-lib-linux-amd64.tar.gz"
 
@@ -22,6 +22,7 @@ usage() {
     echo "Options:"
     echo "  -j  install JAI support"
     echo "  -r  removes previous JAI installation"
+    echo "  -f  GeoServer library folder (defaults to './webapps/geoserver/WEB-INF/lib')"
     echo "  -h  display this help text and exit"
 }
 
@@ -29,13 +30,16 @@ usage() {
 # Each time getopts is invoked, it will place the next option in the shell variable $opt.
 # If the first character of OPTSTRING is a colon, getopts uses silent error reporting.
 # If an invalid option is seen, getopts places the option character found into $OPTARG.
-while getopts :jrh opt; do
+while getopts :jrhf: opt; do
     case $opt in
     j)  # Install JAI support
         INSTALL_JAI=yes
         ;;
     r)  # Reinstall; removes previous install
         REINSTALL=yes
+        ;;
+    f) # GeoServer library folder
+        GEOSERVER_LIB_PATH=$OPTARG
         ;;
     h)  # Help!
         echo "Installs Java Advanced Imaging (JAI) in the WWSK JRE"
@@ -52,6 +56,8 @@ while getopts :jrh opt; do
         ;;
     esac
 done
+
+GEOSERVER_SAVE_PATH=${GEOSERVER_LIB_PATH}/../save
 
 # Place in interactive mode if no command line arguments
 if [[ ! "$*" ]]; then

--- a/resources/jai/setup-jai.sh
+++ b/resources/jai/setup-jai.sh
@@ -2,7 +2,7 @@
 set +x
 
 # -----------------------------------------------------------------------------
-# Setup JAI for the World Wind Server Kit (WWSK) - Linux 
+# Setup JAI for the World Wind Server Kit (WWSK) - Linux
 # -----------------------------------------------------------------------------
 
 # File and paths

--- a/travis/run_integration_tests.sh
+++ b/travis/run_integration_tests.sh
@@ -79,7 +79,7 @@ popd
 ## --------------------------------------------------
 echo "Installing Java Advanced Imaging (JAI)"
 pushd $BUILD_FOLDER
-./setup-jai.sh
+./setup-jai.sh -jf ${PWD}/worldwind-geoserver/WEB-INF/lib
 popd
 
 echo "Running the integration tests with GDAL and JAI"

--- a/travis/run_integration_tests.sh
+++ b/travis/run_integration_tests.sh
@@ -32,7 +32,7 @@ cp $RESOURCES_FOLDER/jai/setup-jai.sh $BUILD_FOLDER
 ## -------------------------------------------------- 
 ## Install the Java Server JRE into the target folder
 ## --------------------------------------------------  
-echo "Installing the Java JRE"
+echo "[INFO] Installing the Java JRE"
 # Unzip the JRE from the parent project resources
 pushd $BUILD_FOLDER
 ./setup-java.sh
@@ -42,7 +42,11 @@ popd
 ## --------------------------------------------------
 # Run the basic tests with the configured JRE
 ## --------------------------------------------------
-echo "Running the integration tests"
+echo
+echo "[INFO] ***********************************"
+echo "[INFO] Running the basic integration tests"
+echo "[INFO] ***********************************"
+echo
 pushd $PROJECT_FOLDER
 mvn verify -P integration-test  2> basic_test_errors.log
 basic_exit_status=$?
@@ -51,7 +55,7 @@ popd
 ## --------------------------------------------------
 # Run the tests again with GDAL 
 ## --------------------------------------------------
-echo "Installing GDAL"
+echo "[INFO] Installing GDAL"
 pushd $BUILD_FOLDER
 ./setup-gdal.sh -gemf ${PWD}/worldwind-geoserver/WEB-INF/lib
 GDAL_HOME_PATH=${PWD}"/gdal"
@@ -59,6 +63,7 @@ export GDAL_LIB_PATH=${GDAL_HOME_PATH}"/lib"
 export GDAL_DATA_PATH=${GDAL_HOME_PATH}"/data"
 export LD_LIBRARY_PATH=${GDAL_LIB_PATH}:${LD_LIBRARY_PATH}
 popd
+
 ## HACK for JP2ECW and ECW crash (defines an environment var used by the ECW driver)
 if [ -z "${NCS_USER_PREFS}" ]; then
     if [ ! -z "${HOME}" ]; then
@@ -68,7 +73,11 @@ if [ -z "${NCS_USER_PREFS}" ]; then
     fi
 fi
 
-echo "Running the integration tests with GDAL"
+echo
+echo "[INFO] ***************************************"
+echo "[INFO] Running the integration tests with GDAL"
+echo "[INFO] ***************************************"
+echo
 pushd $PROJECT_FOLDER
 mvn verify -P integration-test-gdal 2> gdal_test_errors.log
 gdal_exit_status=$?
@@ -77,12 +86,16 @@ popd
 ## --------------------------------------------------
 # Run the tests again with GDAL and JAI
 ## --------------------------------------------------
-echo "Installing Java Advanced Imaging (JAI)"
+echo "[INFO] Installing Java Advanced Imaging (JAI)"
 pushd $BUILD_FOLDER
 ./setup-jai.sh -jf ${PWD}/worldwind-geoserver/WEB-INF/lib
 popd
 
-echo "Running the integration tests with GDAL and JAI"
+echo
+echo "[INFO] ***********************************************"
+echo "[INFO] Running the integration tests with GDAL and JAI"
+echo "[INFO] ***********************************************"
+echo
 pushd $PROJECT_FOLDER
 mvn verify -P integration-test-jai  2> jai_test_errors.log
 jai_exit_status=$?
@@ -101,17 +114,17 @@ LD_LIBRARY_PATH=${OLD_LD_LIBRARY_PATH}
 ## --------------------------------------------------
 exit_status=0
 if [ $basic_exit_status -ne 0 ]; then
-    echo "*** The basic integration tests failed."
+    echo "[ERROR] The basic integration tests failed."
     grep httpSample worldwind-geoserver/target/jmeter/logs/error.log     
     exit_status=1
 fi
 if [ $gdal_exit_status -ne 0 ]; then
-    echo "*** The GDAL integration tests failed."
+    echo "[ERROR] The GDAL integration tests failed."
     grep httpSample worldwind-geoserver/target/jmeter/logs/error-gdal.log     
     exit_status=1
 fi
 if [ $jai_exit_status -ne 0 ]; then
-    echo "*** The JAI integration tests failed."
+    echo "[ERROR] The JAI integration tests failed."
     grep httpSample worldwind-geoserver/target/jmeter/logs/error-jai.log     
     exit_status=1
 fi

--- a/worldwind-geoserver/pom.xml
+++ b/worldwind-geoserver/pom.xml
@@ -167,6 +167,10 @@
             <groupId>org.geoserver.security</groupId>
             <artifactId>gs-sec-ldap</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.geoserver.extension</groupId>
+            <artifactId>gs-control-flow</artifactId>
+        </dependency>
         
         <!--Web Processing Service extension-->
         <dependency>

--- a/worldwind-geoserver/src/main/webapp/data/controlflow.properties
+++ b/worldwind-geoserver/src/main/webapp/data/controlflow.properties
@@ -1,0 +1,57 @@
+### Total OWS request count
+## The global number of OWS requests executing in parallel can be specified with:
+## Every request in excess will be queued and executed when other requests complete 
+## leaving some free execution slot.
+#ows.global=<count>
+##
+### Per request control
+## A per request type control can be demanded using the following syntax:
+#ows.<service>[.<request>[.<outputFormat>]]=<count>
+## Where:
+##  <service> is the OWS service in question (at the time of writing can be wms, wfs, wcs)
+##  <request>, optional, is the request type. For example, for the wms service it can be GetMap, GetFeatureInfo, DescribeLayer, GetLegendGraphics, GetCapabilities
+##  <outputFormat>, optional, is the output format of the request. For example, for the wms GetMap request it could be image/png, image/gif and so on
+##
+### Per user concurrency control
+## There are two mechanisms to identify user requests. The first one is cookie based, 
+## so it will work fine for browsers but not as much for other kinds of clients. The 
+## second one is ip based, which works for any type of client but that can limit all 
+## the users sitting behind the same router. This avoids a single user (as identified 
+## by a cookie) to make too many requests in parallel:
+#user=<count>
+## Where <count> is the maximum number of requests a single user can execute in parallel.
+##
+## The following avoids a single ip address from making too many requests in parallel:
+# ip=<count>
+## Where <count> is the maximum number of requests a single ip address can execute in parallel.
+##
+## It is also possible to make this a bit more specific and throttle a single ip address instead by using the following:
+# ip.<ip_addr>=<count>
+## Where <count> is the maximum number of requests the ip speficied in <ip_addr> will execute in parallel.
+##
+## To reject requests from a list of ip addresses:
+# ip.blacklist=<ip_addr1>,<ip_addr2>,...
+
+
+## Example
+# If a request waits in queue for more than 60 seconds it's not worth executing,
+# the client will  likely have given up by then
+#timeout=60
+
+# Don't allow the execution of more than 100 requests total in parallel
+#ows.global=100
+
+# Don't allow more than 10 GetMap in parallel
+#ows.wms.getmap=10
+
+# Don't allow more than 4 outputs with Excel output as it's memory bound
+#ows.wfs.getfeature.application/msexcel=4
+
+# Don't allow a single user to perform more than 6 requests in parallel
+# (6 being the Firefox default concurrency level at the time of writing)
+#user=6
+
+# Don't allow the execution of more than 16 tile requests in parallel
+# (assuming a server with 4 cores, GWC empirical tests show that throughput
+# peaks up at 4 x number of cores. Adjust as appropriate to your system)
+#ows.gwc=16

--- a/worldwind-geoserver/test-integration-tests.sh
+++ b/worldwind-geoserver/test-integration-tests.sh
@@ -92,7 +92,7 @@ gdal_exit_status=$?
 ## --------------------------------------------------
 echo "Installing Java Advanced Imaging (JAI)"
 pushd target
-./setup-jai.sh
+./setup-jai.sh -jf ${PWD}/worldwind-geoserver/WEB-INF/lib
 popd
 echo
 echo "[INFO] ***********************************************"


### PR DESCRIPTION
Added the `gs-control-flow` module with a default `controlflow.properties` file to the WWSK build.

The control-flow module allows the administrator to control the amount of concurrent requests actually executing inside the server.  It is controlled by the rules defined in controlflow.properties file located in the data_dir folder.  All the rules are disabled in the included controlflow.properties file.

The rules can edited/saved with a text editor without having to restart GeoServer.

See documentation: http://docs.geoserver.org/latest/en/user/extensions/controlflow/index.html

Closes #102 

