### PR TITLE
Add the GeoServer Importer extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,21 @@
                 <version>${gs.version}</version>
             </dependency>               
             
+            <dependency>
+                <groupId>org.geoserver.importer</groupId>
+                <artifactId>gs-importer-core</artifactId>
+                <version>${gs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geoserver.importer</groupId>
+                <artifactId>gs-importer-rest</artifactId>
+                <version>${gs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geoserver.importer</groupId>
+                <artifactId>gs-importer-web</artifactId>
+                <version>${gs.version}</version>
+            </dependency>            
             
             <dependency>
                 <groupId>org.geotools</groupId>

--- a/worldwind-geoserver/pom.xml
+++ b/worldwind-geoserver/pom.xml
@@ -171,6 +171,18 @@
             <groupId>org.geoserver.extension</groupId>
             <artifactId>gs-control-flow</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.geoserver.importer</groupId>
+            <artifactId>gs-importer-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver.importer</groupId>
+            <artifactId>gs-importer-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geoserver.importer</groupId>
+            <artifactId>gs-importer-web</artifactId>
+        </dependency>
         
         <!--Web Processing Service extension-->
         <dependency>


### PR DESCRIPTION
The Importer extension gives a GeoServer administrator an alternate, more-streamlined method for uploading and configuring new layers.

Closes #103 